### PR TITLE
Switch to callback-driven approach in Main.cpp

### DIFF
--- a/Minigin/InputManager.cpp
+++ b/Minigin/InputManager.cpp
@@ -1,21 +1,18 @@
 #include <SDL3/SDL.h>
 #include "InputManager.h"
 
-bool dae::InputManager::ProcessInput()
+bool dae::InputManager::ProcessInput(SDL_Event& event)
 {
-	SDL_Event e;
-	while (SDL_PollEvent(&e)) {
-		if (e.type == SDL_EVENT_QUIT) {
-			return false;
-		}
-		if (e.type == SDL_EVENT_KEY_DOWN) {
-			
-		}
-		if (e.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
-			
-		}
-		// etc...
+	if (event.type == SDL_EVENT_QUIT) {
+		return false;
 	}
+	if (event.type == SDL_EVENT_KEY_DOWN) {
+
+	}
+	if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+
+	}
+	// etc...
 
 	return true;
 }

--- a/Minigin/InputManager.h
+++ b/Minigin/InputManager.h
@@ -6,7 +6,7 @@ namespace dae
 	class InputManager final : public Singleton<InputManager>
 	{
 	public:
-		bool ProcessInput();
+		bool ProcessInput(SDL_Event& event);
 	};
 
 }

--- a/Minigin/Main.cpp
+++ b/Minigin/Main.cpp
@@ -1,3 +1,4 @@
+#define SDL_MAIN_USE_CALLBACKS
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
 
@@ -34,7 +35,8 @@ static void load()
 	scene.Add(std::move(to));
 }
 
-int main(int, char*[]) {
+SDL_AppResult SDL_AppInit(void** const appstate, int const, char** const)
+{
 #if __EMSCRIPTEN__
 	fs::path data_location = "";
 #else
@@ -42,7 +44,27 @@ int main(int, char*[]) {
 	if(!fs::exists(data_location))
 		data_location = "../Data/";
 #endif
-	dae::Minigin engine(data_location);
-	engine.Run(load);
-    return 0;
+
+	*appstate = new dae::Minigin(data_location);
+	load();
+	return SDL_APP_CONTINUE;
+}
+
+SDL_AppResult SDL_AppIterate(void* const appstate)
+{
+	static_cast<dae::Minigin*>(appstate)->RunOneFrame();
+	return SDL_APP_CONTINUE;
+}
+
+SDL_AppResult SDL_AppEvent(void* const appstate, SDL_Event* const event)
+{
+	return
+		static_cast<dae::Minigin*>(appstate)->ProcessEvent(*event)
+			? SDL_APP_CONTINUE
+			: SDL_APP_SUCCESS;
+}
+
+void SDL_AppQuit(void* const appstate, SDL_AppResult const)
+{
+	delete static_cast<dae::Minigin*>(appstate);
 }

--- a/Minigin/Minigin.cpp
+++ b/Minigin/Minigin.cpp
@@ -29,15 +29,6 @@ void LogSDLVersion(const std::string& message, int major, int minor, int patch)
 #endif
 }
 
-#ifdef __EMSCRIPTEN__
-#include "emscripten.h"
-
-void LoopCallback(void* arg)
-{
-	static_cast<dae::Minigin*>(arg)->RunOneFrame();
-}
-#endif
-
 // Why bother with this? Because sometimes students have a different SDL version installed on their pc.
 // That is not a problem unless for some reason the dll's from this project are not copied next to the exe.
 // These entries in the debug output help to identify that issue.
@@ -87,20 +78,13 @@ dae::Minigin::~Minigin()
 	SDL_Quit();
 }
 
-void dae::Minigin::Run(const std::function<void()>& load)
-{
-	load();
-#ifndef __EMSCRIPTEN__
-	while (!m_quit)
-		RunOneFrame();
-#else
-	emscripten_set_main_loop_arg(&LoopCallback, this, 0, true);
-#endif
-}
-
 void dae::Minigin::RunOneFrame()
 {
-	m_quit = !InputManager::GetInstance().ProcessInput();
 	SceneManager::GetInstance().Update();
 	Renderer::GetInstance().Render();
+}
+
+bool dae::Minigin::ProcessEvent(SDL_Event& event)
+{
+	return InputManager::GetInstance().ProcessInput(event);
 }

--- a/Minigin/Minigin.h
+++ b/Minigin/Minigin.h
@@ -7,12 +7,11 @@ namespace dae
 {
 	class Minigin final
 	{
-		bool m_quit{};
 	public:
 		explicit Minigin(const std::filesystem::path& dataPath);
 		~Minigin();
-		void Run(const std::function<void()>& load);
 		void RunOneFrame();
+		bool ProcessEvent(SDL_Event& event);
 
 		Minigin(const Minigin& other) = delete;
 		Minigin(Minigin&& other) = delete;


### PR DESCRIPTION
[Most relevant section of the SDL Wiki page about `SDL_MAIN_USE_CALLBACKS`](https://wiki.libsdl.org/SDL3/README-main-functions#:~:text=Main%20callbacks%20in,like%20this%20more!)

TL;DR: In some situations a traditional `while` loop cannot be used, like when compiling with Emscripten. The engine handles that properly by using some `#ifdef`s. However, SDL provides a callback driven alternative to the entry point code which satisfies a wider range of platforms/targets, including Emscripten.

**Upside**: handeling of specific platform/target cases in regard of the entry point can be passed to SDL completely.

**Downsides**: students don't get to see the widely used game loop in practice but instead are shown a callback driven abstraction.